### PR TITLE
cb-ext frequent pod crash issue due to contact point

### DIFF
--- a/src/main/java/org/sunbird/common/helper/cassandra/CassandraConnectionManagerImpl.java
+++ b/src/main/java/org/sunbird/common/helper/cassandra/CassandraConnectionManagerImpl.java
@@ -69,8 +69,6 @@ public class CassandraConnectionManagerImpl implements CassandraConnectionManage
             String[] hosts = null;
             if (StringUtils.isNotBlank(cassandraHost)) {
                 hosts = cassandraHost.split(",");
-            } else {
-                hosts = new String[] {"localhost"};
             }
             cluster = createCluster(hosts, poolingOptions);
 

--- a/src/main/java/org/sunbird/common/helper/cassandra/CassandraConnectionManagerImpl.java
+++ b/src/main/java/org/sunbird/common/helper/cassandra/CassandraConnectionManagerImpl.java
@@ -66,7 +66,12 @@ public class CassandraConnectionManagerImpl implements CassandraConnectionManage
             poolingOptions.setPoolTimeoutMillis(
                     Integer.parseInt(cache.getProperty(Constants.POOL_TIMEOUT)));
             String cassandraHost = (cache.getProperty(Constants.CASSANDRA_CONFIG_HOST));
-            String[] hosts = new String[]{cassandraHost};
+            String[] hosts = null;
+            if (StringUtils.isNotBlank(cassandraHost)) {
+                hosts = cassandraHost.split(",");
+            } else {
+                hosts = new String[] {"localhost"};
+            }
             cluster = createCluster(hosts, poolingOptions);
 
             final Metadata metadata = cluster.getMetadata();


### PR DESCRIPTION
Cb-EXT frequent pod crash issue due to contact points. It was unable to parse multiple cassandra ip's from config.Fixes are one with this PR