### PR TITLE
KB-1893 : Karma Points should be sorted on the Last credited date in the ascending order when the karma points are same.

### DIFF
--- a/src/main/java/org/sunbird/halloffame/service/HallOfFameServiceImpl.java
+++ b/src/main/java/org/sunbird/halloffame/service/HallOfFameServiceImpl.java
@@ -115,6 +115,15 @@ public class HallOfFameServiceImpl implements HallOfFameService {
             }
             resultMap.get(map.get(Constants.ORGID)).put(Constants.RANK, rank);
         }
+
+        resultMap = resultMap.entrySet()
+                .stream()
+                .sorted(Comparator
+                        .comparing((Map.Entry<String, Map<String, Object>> entry) -> (Float) entry.getValue().get("average_kp"))
+                        .thenComparing(entry -> (Date) entry.getValue().get("latest_credit_date")))
+                .collect(LinkedHashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), LinkedHashMap::putAll);
+
+
         return resultMap;
     }
 }


### PR DESCRIPTION
1. Will be iterating over the map and checking the average_kp points are same if any case they are same they would be sorted in the ascending order of the latest_credtited_date.