### PR TITLE
KB-1893 : Karma Points should be sorted on the Last credited date in the ascending order when the karma points are same

### DIFF
--- a/src/main/java/org/sunbird/halloffame/service/HallOfFameServiceImpl.java
+++ b/src/main/java/org/sunbird/halloffame/service/HallOfFameServiceImpl.java
@@ -119,10 +119,10 @@ public class HallOfFameServiceImpl implements HallOfFameService {
         resultMap = resultMap.entrySet()
                 .stream()
                 .sorted(Comparator
-                        .comparing((Map.Entry<String, Map<String, Object>> entry) -> (Float) entry.getValue().get("average_kp"))
+                        .comparing((Map.Entry<String, Map<String, Object>> entry) -> (Integer) entry.getValue().get("rank"))
+                        .thenComparing(entry -> (Float) entry.getValue().get("average_kp"))
                         .thenComparing(entry -> (Date) entry.getValue().get("latest_credit_date")))
                 .collect(LinkedHashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), LinkedHashMap::putAll);
-
 
         return resultMap;
     }


### PR DESCRIPTION

1. Updated the logic for sorting.