### PR TITLE
  KB-3171 | BE | Dev | Enhancement of the API for downloading a password-protected zip report

### DIFF
--- a/src/main/java/org/sunbird/operationalreports/service/OperationalReportServiceImpl.java
+++ b/src/main/java/org/sunbird/operationalreports/service/OperationalReportServiceImpl.java
@@ -215,12 +215,10 @@ public class OperationalReportServiceImpl implements OperationalReportService {
             // Prepare InputStreamResource for the file to be downloaded
             InputStreamResource inputStreamResource = new InputStreamResource(Files
                     .newInputStream(Paths.get(sourceFolderPath + "/" + serverProperties.getOperationReportFileName())));
-            // Clean up temporary files
-            removeDirectory(sourceFolderPath);
             // Return ResponseEntity with the file for download
             return ResponseEntity.ok()
                     .headers(headers)
-                    .contentLength(Files.size(filePath))
+                    .contentLength(Files.size(Paths.get(sourceFolderPath + "/" + serverProperties.getOperationReportFileName())))
                     .body(inputStreamResource);
         } catch (Exception e) {
             logger.error("Failed to read the downloaded file: " + serverProperties.getOperationReportFileName()


### PR DESCRIPTION

1. For large file if we are removing the directory willl get io exceptions so removed the method .
2. Path issue was causing corruption issue so fixed the path in contentLength().