### PR TITLE
KB-3171 | BE | Dev | Enhancement of the API for downloading a password-protected zip report

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -388,7 +388,7 @@ digilocker-issuer-id=karmayogibharat.gov.in
 digilocker-api-key=api-key
 report.property.file.allMdo=ContentCompetencyMapping.csv
 
-operational.reports.passwordlength=15
+operational.reports.passwordlength=5
 operational.reports.unzip.password=123456
 es.default.result.limit=250
 secret.key.token.validation=secretKey


### PR DESCRIPTION
1.  Password length chagned to 5.