### PR TITLE
4.8.14 dev v9 (#594)

### DIFF
--- a/src/main/java/org/sunbird/common/util/ProjectUtil.java
+++ b/src/main/java/org/sunbird/common/util/ProjectUtil.java
@@ -200,7 +200,7 @@ public class ProjectUtil {
 	}
 
 	public static Boolean validateEmployeeId(String employeeId) {
-		return employeeId.matches("^(?=.*\\d|[a-zA-Z]{30})[a-zA-Z0-9 .-]{1,30}$"); // Allow only alphanumeric, numeric and restrict if only alphabets character
+		return employeeId.matches("^[a-zA-Z0-9]{1,30}$"); // Allow only alphanumeric,numeric and alphabetic.
 	}
 
 	public static Boolean validateRegexPatternWithNoSpecialCharacter(String regex) {

--- a/src/main/java/org/sunbird/profile/service/UserBulkUploadService.java
+++ b/src/main/java/org/sunbird/profile/service/UserBulkUploadService.java
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.util.CollectionUtils;
-import org.sunbird.cache.RedisCacheMgr;
 import org.sunbird.cassandra.utils.CassandraOperation;
 import org.sunbird.common.model.SBApiResponse;
 import org.sunbird.common.util.CbExtServerProperties;


### PR DESCRIPTION
* 4.8.14 dev v9 (#589)

* 4.8.15 dev v1 (#584)

* KB-4705 | DEV| Assessment | BE | Consumption Logic for the QuestionWeightage Assessment Type (#564)

* Added string handling in admin patch API

* Assessment V5 Changes

Assessment V5 Changes

* KB-4705 | DEV| Assessment | BE | Consumption Logic for the QuestionWeightage Assessment Type

1. Removed the hardcoded attributes and added from assessment hierarchy.

* KB-4705 | DEV| Assessment | BE | Consumption Logic for the QuestionWeightage Assessment Type

1. Added proper comments and logs.
2. Refractored the code.
3. Added logic for optionweightage.

---------



* Retry Attempts Enabled for Assessment V5

* KB-4705 | DEV| Assessment | BE | Consumption Logic for the QuestionWeightage Assessment Type (#565)

1. Optional weightage score calculation enhancements.

* Adding the insight API implementation for MDO channel (#571)

* SaveStateMethod

* Maintaining the order of the fields.

* KB-4705 | DEV| Assessment | BE | Consumption Logic for the QuestionWeightage Assessment Type (#580)

1. Enhanchements for questionScheme.

* KB-5130 | DEV| Assessment | BE | Enhancement in Consumption Logic for the QuestionWeightage Assessment Type. (#581)

1. Added logic for new attributes added.
2. Added questionLevel param in Question read API.

* KB-5130 | DEV| Assessment | BE | Enhancement in Consumption Logic for the QuestionWeightage Assessment Type. (#583)

1. Score calculation fix.

---------





* KB-4754:Validation for language, designation fix

* removed changes from cbrelaease-4.8.15

* Modified error message on date of birth validation failure

* changed approach for fetchind and storing data from redis

---------






* KB-4754 changed regex for employee Id to allow all alphabets, updated error message for employee Id containing spaces.

---------